### PR TITLE
Add edit/delete actions, year support, and custom export file names

### DIFF
--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -26,6 +26,9 @@
   "expense": "Expense",
   "aiUnavailableTitle": "AI Service Unavailable",
   "aiUnavailableMessage": "Scan Bill (AI) is currently not available. Please try again later.",
+  "edit":"✏️ Edit",
+  "delete":"🗑️ Delete",
+  "save":"Save",
   "months": [
     "January",
     "February",

--- a/src/locales/sq.json
+++ b/src/locales/sq.json
@@ -26,6 +26,9 @@
   "expense": "Shpenzime",
   "aiUnavailableTitle": "Shërbimi AI Nuk Është i Disponueshëm",
   "aiUnavailableMessage": "Skano Faturën (AI - Inteligjencë Artificiale) nuk është aktualisht i disponueshëm. Ju lutemi provoni më vonë.",
+  "edit":"✏️ Ndrysho",
+  "delete":"🗑️ Fshij",
+  "save":"Ruaj",
   "months": [
     "Janar",
     "Shkurt",

--- a/src/utils/exportToExcel.js
+++ b/src/utils/exportToExcel.js
@@ -1,7 +1,12 @@
 import ExcelJS from "exceljs";
 import { saveAs } from "file-saver";
 
-export const exportToExcel = async ({ entries, totals, title }) => {
+export const exportToExcel = async ({
+  entries,
+  totals,
+  title,
+  fileName = "finance-report",
+}) => {
   const workbook = new ExcelJS.Workbook();
   const sheet = workbook.addWorksheet("Finance Report");
 
@@ -11,7 +16,13 @@ export const exportToExcel = async ({ entries, totals, title }) => {
   titleCell.font = { size: 16, bold: true };
   titleCell.alignment = { horizontal: "center" };
 
-  const headerRow = sheet.addRow(["Month", "Type", "Category", "Description", "Amount"]);
+  const headerRow = sheet.addRow([
+    "Month",
+    "Type",
+    "Category",
+    "Description",
+    "Amount",
+  ]);
   headerRow.eachCell((cell) => {
     cell.font = { bold: true };
     cell.fill = {
@@ -28,7 +39,13 @@ export const exportToExcel = async ({ entries, totals, title }) => {
   });
 
   entries.forEach((e) => {
-    sheet.addRow([e.month, e.type, e.category, e.description, Number(e.actual)]);
+    sheet.addRow([
+      e.month,
+      e.type,
+      e.category,
+      e.description,
+      Number(e.actual),
+    ]);
   });
 
   sheet.addRow([]);
@@ -41,5 +58,5 @@ export const exportToExcel = async ({ entries, totals, title }) => {
   const blob = new Blob([buffer], {
     type: "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet",
   });
-  saveAs(blob, "finance-report.xlsx");
+  saveAs(blob, `${fileName}.xlsx`);
 };

--- a/src/utils/exportToPDF.js
+++ b/src/utils/exportToPDF.js
@@ -1,6 +1,10 @@
 import html2pdf from "html2pdf.js";
 
-export const exportToPDF = ({ element, darkMode }) => {
+export const exportToPDF = ({
+  element,
+  darkMode,
+  fileName = "finance-report",
+}) => {
   const originalDark = darkMode;
   document.body.classList.remove("dark-mode");
   const toHide = element.querySelectorAll(".no-print");
@@ -8,7 +12,7 @@ export const exportToPDF = ({ element, darkMode }) => {
 
   const options = {
     margin: 0.5,
-    filename: "finance-report.pdf",
+    filename: `${fileName}.pdf`, // use dynamic name
     image: { type: "jpeg", quality: 0.98 },
     html2canvas: { scale: 2, useCORS: true },
     jsPDF: { unit: "in", format: "letter", orientation: "portrait" },


### PR DESCRIPTION
Add edit/delete actions, year support, and custom export file names
- Fix month default bug with undefined language
- Persist selected month via localStorage
- Add inline year input next to month selector (nullable, styled)
- Implement edit and delete buttons per entry with SweetAlert forms
- Prompt for custom file name on PDF/Excel export